### PR TITLE
parse piefed instances the same as lemmy instances

### DIFF
--- a/fediseer/fediverse.py
+++ b/fediseer/fediverse.py
@@ -151,6 +151,7 @@ class InstanceInfo():
     def retrieve_admins(self):
         software_map = {
             "lemmy": self.get_lemmy_admins,
+            "piefed": self.get_lemmy_admins,
             "mastodon": self.get_mastodon_admins,
             "friendica": self.get_mastodon_admins,
             "pleroma": self.get_pleroma_admins,
@@ -263,6 +264,7 @@ class InstanceInfo():
             self.version = self.node_info["software"].get("version","unknown")
         software_map = {
             "lemmy": self.get_lemmy_info,
+            "piefed": self.get_lemmy_info,
             "mastodon": self.get_mastodon_info,
             "friendica": self.get_mastodon_info,
             "pleroma": self.get_pleroma_info,


### PR DESCRIPTION
This PR adds support for PieFed instances by interacting with them the same way as Lemmy instances. PieFed tries to return the same json to the same endpoints as Lemmy so it should work.