### PR TITLE
Fix minor syntax error in PM sending.

### DIFF
--- a/fediseer/messaging.py
+++ b/fediseer/messaging.py
@@ -30,7 +30,7 @@ class ActivityPubPM:
             "actor": "https://fediseer.com/api/v1/user/fediseer",
             "@context": [
                 "https://www.w3.org/ns/activitystreams",
-                "https: //w3id.org/security/v1"
+                "https://w3id.org/security/v1"
             ],	
             "object": {
                 "attributedTo": "https://fediseer.com/api/v1/user/fediseer",

--- a/fediseer/messaging.py
+++ b/fediseer/messaging.py
@@ -96,6 +96,7 @@ class ActivityPubPM:
 
     def send_pm(self, document, domain):
         document["id"] = f"https://fediseer.com/{uuid.uuid4()}"
+	document["@id"] = document["id"]
         document["object"]["id"] = f"https://fediseer.com/{uuid.uuid4()}"
         document["object"]["published"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
         document = json.dumps(document, indent=4)


### PR DESCRIPTION
This PR removes an erroneous space, which can cause some softwares issues when receiving API key PM's as the invalid URL will not parse. (notably, this occurs in [Fedify](https://fedify.dev) based implementations), as well as adds the `@id` field (mirroring `id`), which is similarly required.

Additionally, though unrelated to this PR specifically, the Mastodon PM proxy has become defunct with the retirement of botsin.space, and now reports a 401 error on any instance it's attempted on.